### PR TITLE
Bump Miniconda to 4.11.0

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -24,12 +24,6 @@ api = "0.7"
     uri = "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-x86_64.sh"
     version = "4.11.0"
 
-  [[metadata.dependency_deprecation_dates]]
-    date = "2025-10-01T00:00:00Z"
-    link = "https://www.python.org/dev/peps/pep-0596/"
-    name = "miniconda3"
-    version_line = "4.11.x"
-
 [[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -14,21 +14,21 @@ api = "0.7"
   pre-package = "./scripts/build.sh"
 
   [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:conda:miniconda3:4.9.2:*:*:*:*:python:*:*"
+    cpe = "cpe:2.3:a:conda:miniconda3:4.11.0:*:*:*:*:python:*:*"
     id = "miniconda3"
     name = "Miniconda"
-    sha256 = "536817d1b14cb1ada88900f5be51ce0a5e042bae178b5550e62f61e223deae7c"
-    source = "https://github.com/conda/conda/archive/4.9.2.tar.gz"
-    source_sha256 = "d7f946e5c770e45da8961323ca96399bf1a881eb68bbaecc7cb1e249f5c86d54"
+    sha256 = "4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4"
+    source = "https://github.com/conda/conda/archive/4.11.0.tar.gz"
+    source_sha256 = "1843355ccb93afb05f2a307e1fc37403fb9976da799236eebc3adee1c716c5fc"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-x86_64.sh"
-    version = "4.9.2"
+    uri = "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-x86_64.sh"
+    version = "4.11.0"
 
   [[metadata.dependency_deprecation_dates]]
-    date = "2023-06-27T00:00:00Z"
-    link = "https://www.python.org/dev/peps/pep-0537/"
+    date = "2025-10-01T00:00:00Z"
+    link = "https://www.python.org/dev/peps/pep-0596/"
     name = "miniconda3"
-    version_line = "4.7.x"
+    version_line = "4.11.x"
 
 [[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"


### PR DESCRIPTION
Resolves #200.

## Learnings
- Can't bump to Miniconda 4.12.0 (https://github.com/conda/conda/releases) because the installation script isn't available (https://repo.anaconda.com/miniconda/)
- I learned that `source_sha256` is the SHA256 of `source`, and `sha256` is the SHA256 of `uri`

## Questions
- Do we need `metadata.dependency_deprecation_dates`?
- I can't seem to find miniconda in the CPE database. Is that a problem?
- What's the difference between `uri` and `source`?
- Is it strange the the `uri` points to an installation script that seems only for Python 3.9, when `cpython` allows other versions of Python? https://github.com/paketo-buildpacks/cpython/blob/fb81f17a9efac7fcec75617d6e80747b26126c1d/buildpack.toml