### PR TITLE
Support Jammy

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -20,7 +20,7 @@ api = "0.7"
     sha256 = "4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4"
     source = "https://github.com/conda/conda/archive/4.11.0.tar.gz"
     source_sha256 = "1843355ccb93afb05f2a307e1fc37403fb9976da799236eebc3adee1c716c5fc"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
+    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy", "org.cloudfoundry.stacks.cflinuxfs3"]
     uri = "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-x86_64.sh"
     version = "4.11.0"
 
@@ -29,3 +29,6 @@ api = "0.7"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+  id = "io.buildpacks.stacks.jammy"

--- a/integration.json
+++ b/integration.json
@@ -1,3 +1,7 @@
 {
+  "builders": [
+    "index.docker.io/paketobuildpacks/builder:buildpackless-base",
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
+  ],
   "build-plan": "github.com/paketo-community/build-plan"
 }


### PR DESCRIPTION
Support Jammy.

See https://github.com/paketo-buildpacks/python/issues/490 for context.

Note that a quick google search seems to indicate that this script `Miniconda3-py39_4.11.0-Linux-x86_64.sh` is the right way to install Miniconda on any `x86_64` linux.

- https://varhowto.com/install-miniconda-ubuntu-20-04/
- https://www.linuxhowto.net/how-to-install-miniconda-in-linux/