### PR TITLE
Use occam.Source in integration tests.

### DIFF
--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -38,6 +38,9 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -49,8 +52,6 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 
 		it("pack builds and runs the app successfully", func() {
 			var err error
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
 
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.

--- a/integration/reuse_layer_test.go
+++ b/integration/reuse_layer_test.go
@@ -36,8 +36,12 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 		docker = occam.NewDocker()
 		pack = occam.NewPack().WithNoColor()
+
 		imageIDs = map[string]struct{}{}
 		containerIDs = map[string]struct{}{}
+
+		source, err = occam.Source(filepath.Join("testdata", "default_app"))
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	it.After(func() {
@@ -64,9 +68,6 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				firstContainer  occam.Container
 				secondContainer occam.Container
 			)
-
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
 
 			build := pack.Build.
 				WithPullPolicy("never").


### PR DESCRIPTION
## Summary

This PR ensures that each test uses `occam.Source` in a consistent manner. This ensures that we do not accidentally re-use images across tests.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
