### PR TITLE
Bump to miniconda 22.11.1

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -14,15 +14,15 @@ api = "0.7"
   pre-package = "./scripts/build.sh"
 
   [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:conda:miniconda3:4.11.0:*:*:*:*:python:*:*"
+    cpe = "cpe:2.3:a:conda:miniconda3:22.11.1:*:*:*:*:python:*:*"
     id = "miniconda3"
     name = "Miniconda"
-    sha256 = "4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4"
-    source = "https://github.com/conda/conda/archive/4.11.0.tar.gz"
-    source_sha256 = "1843355ccb93afb05f2a307e1fc37403fb9976da799236eebc3adee1c716c5fc"
+    sha256 = "e685005710679914a909bfb9c52183b3ccc56ad7bb84acc861d596fcbe5d28bb"
+    source = "https://github.com/conda/conda/archive/refs/tags/22.11.1.tar.gz"
+    source_sha256 = "f9256a7e71a9f35063b683f6c7823acf05c1f75468fc609954f1f5efae7c03ac"
     stacks = ["*"]
-    uri = "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.11.0-Linux-x86_64.sh"
-    version = "4.11.0"
+    uri = "https://repo.anaconda.com/miniconda/Miniconda3-py39_22.11.1-1-Linux-x86_64.sh"
+    version = "22.11.1"
 
 [[stacks]]
   id = "*"


### PR DESCRIPTION
## Summary

This PR bumps miniconda to 22.1.1. This is the latest version we can bump to without making changes to the buildpack install script. See #262 for more details on compatible versions.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
