### PR TITLE
Implement option to switch to mamba solver

### DIFF
--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -72,5 +72,35 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 			))
 		})
+
+		it("logs helpful information to the user with mamba installation", func() {
+			var (
+				logs fmt.Stringer
+				err  error
+			)
+
+			image, logs, err = pack.WithNoColor().Build.
+				WithEnv(map[string]string{"BP_CONDA_SOLVER": "mamba"}).
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.Miniconda.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs.String)
+
+			Expect(logs).To(ContainLines(
+				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+				"  Executing build process",
+				MatchRegexp(`    Installing Miniconda \d+\.\d+\.\d+`),
+				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+				"",
+				"    Installing mamba solver",
+				MatchRegexp(`      Solver completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+				"",
+				"    Configuring mamba solver",
+				MatchRegexp(`      Configuration completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+			))
+		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR implements the possibility to switch the miniconda solver over to the libmamba solver which powers mamba and is a faster alternative to the default solver.

Fixes #479

## Use Cases
<!-- An explanation of the use cases your change enables -->
This allows people building conda based images to use the faster libmamba solver. The speedup difference allows to more efficiently build images from loosely defined specifications.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
